### PR TITLE
Исправление: zapret2 падает с "setgroups: Invalid argument" без явного --uid

### DIFF
--- a/lib/nft.sh
+++ b/lib/nft.sh
@@ -80,12 +80,18 @@ ZAPRET2_DEFAULT_IN_RANGE="a"
 ZAPRET2_DEFAULT_SPLIT_LEN="400"
 ZAPRET2_DEFAULT_WIN_SYNACK="1400"
 ZAPRET2_DEFAULT_WIN_ACK="10"
-
+# Без явного --uid nfqws2 в некоторых окружениях (unprivileged LXC)
+# падает с "setgroups: Invalid argument" при попытке дропа привилегий
+# по умолчанию. nobody:nogroup — безопасный кросс-дистрибутивный выбор.
+ZAPRET2_DEFAULT_UID="65534"
+ZAPRET2_DEFAULT_GID="65534"
 ZAPRET2_FWMARK="$ZAPRET2_DEFAULT_FWMARK"
 ZAPRET2_QNUM="$ZAPRET2_DEFAULT_QNUM"
 ZAPRET2_OUT_RANGE="$ZAPRET2_DEFAULT_OUT_RANGE"
 ZAPRET2_IN_RANGE="$ZAPRET2_DEFAULT_IN_RANGE"
 ZAPRET2_SPLIT_LEN="$ZAPRET2_DEFAULT_SPLIT_LEN"
+ZAPRET2_UID="$ZAPRET2_DEFAULT_UID"
+ZAPRET2_GID="$ZAPRET2_DEFAULT_GID"
 ZAPRET2_DEBUG="false"
 ZAPRET2_DEBUG_LOG="/var/log/mtproxyl-nfqws2.log"
 ZAPRET2_WIN_SYNACK="$ZAPRET2_DEFAULT_WIN_SYNACK"
@@ -1459,6 +1465,7 @@ zapret2_write_conf() {
 --qnum ${ZAPRET2_QNUM}
 --fwmark=${ZAPRET2_FWMARK}
 --server
+--uid=${ZAPRET2_UID}:${ZAPRET2_GID}
 ${_debug_line}
 --lua-init=@${ZAPRET2_LUA_DIR}/zapret-lib.lua
 --lua-init=@${ZAPRET2_LUA_DIR}/zapret-antidpi.lua


### PR DESCRIPTION
## Проблема

При установке Zapret2 MTProto fix (`zapret2_write_conf`) сгенерированный
`/etc/mtproxyl-zapret2/mtproto.conf` не содержит опции `--uid`/`--user`.
В этом случае nfqws2 использует значение по умолчанию для смены
UID/GID при сбросе привилегий, что в некоторых окружениях
(в частности, внутри LXC-контейнеров) приводит к падению службы:

    setgroups: Invalid argument

Служба не стартует, health-check в установщике это фиксирует и
откатывает установку (`[!] zapret2 не запустился — выполняю откат`).

Проверено: контейнер unprivileged, id-mapping полный
(root:100000:65536 в /etc/subuid и /etc/subgid), `nobody`/`nogroup`
в системе присутствуют и корректны (65534:65534) — то есть причина
не в LXC id-mapping, а в отсутствии явного `--uid` в конфиге nfqws2.

## Исправление

Добавлены `ZAPRET2_DEFAULT_UID="65534"` / `ZAPRET2_DEFAULT_GID="65534"`
(по аналогии с остальными `ZAPRET2_DEFAULT_*`) и рабочие переменные
`ZAPRET2_UID`/`ZAPRET2_GID`, которые теперь явно передаются в
генерируемый конфиг как `--uid=${ZAPRET2_UID}:${ZAPRET2_GID}`.
nobody:nogroup (65534:65534) — стандартный непривилегированный
пользователь/группа на большинстве Linux-дистрибутивов.

## Проверка

- Установка Zapret2 MTProto fix в unprivileged LXC-контейнере
  (Proxmox, Debian/Ubuntu) — служба стартует и остаётся активной,
  `setgroups: Invalid argument` не появляется.