### PR TITLE
Fix possible fix(deps): 5 vulnerable dependencies in go.mod

### DIFF
--- a/mtproxyl-panel/go.mod
+++ b/mtproxyl-panel/go.mod
@@ -13,7 +13,7 @@ require (
 )
 
 require (
-	golang.org/x/net v0.54.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
-	golang.org/x/text v0.37.0 // indirect
+	golang.org/x/text v0.39.0 // indirect
 )


### PR DESCRIPTION
This changes `mtproxyl-panel/go.mod` to address something a scan flagged. It is around line 1.

The project depends on golang.org/x/net v0.54.0, which contains a vulnerability (CVE-2026-25681) that allows parsing of untrusted HTML to produce an unexpected DOM tree, leading to potential cross‑site scripting (XSS) when the rendered output is sent to a browser. This is a high‑severity issue because an attacker could inject malicious scripts that run in the context of the victim's session, compromising data and user trust. Upgrading to the patched version (v0.55.0) eliminates the vulnerable code path.

Update golang.org/x/net and golang.org/x/text to versions that resolve the reported CVE advisories.

For reference: rule `CVE-2026-25681`. Rated high.

I may well be missing context here — if the current code is deliberate, feel free to close this.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
